### PR TITLE
StreamEvents: Fix NPE when invoking the command with --help

### DIFF
--- a/gerrit-sshd/src/main/java/com/google/gerrit/sshd/commands/StreamEvents.java
+++ b/gerrit-sshd/src/main/java/com/google/gerrit/sshd/commands/StreamEvents.java
@@ -169,9 +169,15 @@ final class StreamEvents extends BaseCommand {
             .create();
   }
 
+  private void removeEventListenerRegistration() {
+    if (eventListenerRegistration != null) {
+      eventListenerRegistration.remove();
+    }
+  }
+
   @Override
   protected void onExit(final int rc) {
-    eventListenerRegistration.remove();
+    removeEventListenerRegistration();
 
     synchronized (taskLock) {
       done = true;
@@ -182,7 +188,7 @@ final class StreamEvents extends BaseCommand {
 
   @Override
   public void destroy() {
-    eventListenerRegistration.remove();
+    removeEventListenerRegistration();
 
     final boolean exit;
     synchronized (taskLock) {
@@ -230,7 +236,7 @@ final class StreamEvents extends BaseCommand {
         // destroy() above, or it closed the stream and is no longer
         // accepting output. Either way terminate this instance.
         //
-        eventListenerRegistration.remove();
+        removeEventListenerRegistration();
         flush();
         onExit(0);
         return;


### PR DESCRIPTION
When executing the command:

  ssh user@host gerrit stream-events --help

the onExit and destroy methods attempt to remove the event listener
registration which has not been initialized, resulting in NPE and
the command hanging.

Add null checks to prevent this.

Change-Id: I1b9ccd41d017e62f0a4206114ab15faa6ed8e000