### PR TITLE
feat: Added Elestio as one-click deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ authorized user to submit changes to the master Git repository, rather
 than requiring all approved changes to be merged in by hand by the project
 maintainer.
 
+## Self-Hosting
+
+### Elestio
+
+You can deploy Gerrit on Elestio using one-click deployment. Elestio handles version updates, maintenance, securtiy, backups, etc. Additionally, Elestio supports Gerrit by providing revenue share so go ahead and click below to deploy and start using.
+
+[![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/gerrit)
+
 ## Documentation
 
 For information about how to install and use Gerrit, refer to


### PR DESCRIPTION
Hey team,
I am Kaiwalya, Developer Advocate at Elestio. Elestio has been providing options of fully deploying and managing Gerrit application as shown [here](https://elest.io/open-source/gerrit). I think it would be a great idea if we can add it to official readme/documentation here.
🔔 In addition to this, if you are interested we provide partnership opportunities with tools we support by **revenue share** upon addition of this method in docs. If you would like to collaborate, just shoot me an email at [kaiwalya@elest.io](mailto:kaiwalya@elest.io) :)