### PR TITLE
Chain errors in pack_refs

### DIFF
--- a/contrib/maintenance/git/repo.py
+++ b/contrib/maintenance/git/repo.py
@@ -114,7 +114,7 @@ def pack_refs(repo_dir, all=False):
             LOG.info(e.stdout)
         if e.stderr:
             LOG.error(e.stderr)
-        raise GitCommandException(f"Failed to pack refs in {repo_dir}")
+        raise GitCommandException(f"Failed to pack refs in {repo_dir}") from e
 
 
 def gc(repo_dir, git_config=None, args=None):


### PR DESCRIPTION
Spotted something in contrib/maintenance/git/repo.py that might be worth a look: The wrapper exception drops the original cause. this patch chains it with from so the real failure still shows up in tracebacks — happy to close if this isn’t useful.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.