### PR TITLE
Fix login form: use label elements instead of th for accessibility

### DIFF
--- a/resources/com/google/gerrit/httpd/auth/ldap/LoginForm.html
+++ b/resources/com/google/gerrit/httpd/auth/ldap/LoginForm.html
@@ -24,14 +24,14 @@
       <form method="POST" action="#" id="login_form" autocomplete="off" onsubmit="return shouldSubmit()">
         <table style="border: 0;">
         <tr>
-          <th>Username</th>
+          <td><label for="f_user">Username</label></td>
           <td><input name="username" id="f_user"
                      type="text"
                      size="25"
                      tabindex="1" /></td>
         </tr>
         <tr>
-          <th>Password</th>
+          <td><label for="f_pass">Password</label></td>
           <td><input name="password" id="f_pass"
                      type="password"
                      size="25"


### PR DESCRIPTION
There was no label attribute for the login form input fields 